### PR TITLE
Update Model implementations to use dataclasses

### DIFF
--- a/alembic/env.py
+++ b/alembic/env.py
@@ -7,7 +7,7 @@ from sqlalchemy import pool
 # this is the Alembic Config object, which provides
 # access to the values within the .ini file in use.
 from src.config import DATABASE_URI
-from src.helpers.sqlalchemy_helpers import BaseModel
+from src.helpers.sqlalchemy_helpers import mapper_registry
 
 config = context.config
 
@@ -21,7 +21,7 @@ config.set_main_option("sqlalchemy.url", DATABASE_URI)
 # for 'autogenerate' support
 # from myapp import mymodel
 # target_metadata = mymodel.Base.metadata
-target_metadata = BaseModel.metadata
+target_metadata = mapper_registry.metadata
 
 
 # other values from the config, defined by the needs of env.py,

--- a/src/conftest.py
+++ b/src/conftest.py
@@ -12,7 +12,7 @@ from asynctest import MagicMock as AsyncMagicMock
 from sqlalchemy import inspect
 
 from src.containers import Container
-from src.helpers.sqlalchemy_helpers import BaseModel
+from src.helpers.sqlalchemy_helpers import mapper_registry
 from src.models import User
 from src.repositories import BaseRepository
 from src.test_config import TEST_ASYNC_DATABASE_URI
@@ -70,7 +70,7 @@ def _database_url() -> str:  # noqa: PT005
 
 @pytest.fixture(scope="session")
 def init_database() -> Callable:
-    return BaseModel.metadata.create_all
+    return mapper_registry.metadata.create_all
 
 
 @pytest.fixture()

--- a/src/containers.py
+++ b/src/containers.py
@@ -3,7 +3,6 @@ from contextlib import asynccontextmanager
 from logging import getLogger
 from logging.config import dictConfig
 from typing import AsyncGenerator
-from typing import List
 
 from dependency_injector.containers import DeclarativeContainer
 from dependency_injector.providers import Configuration
@@ -25,7 +24,7 @@ from src.services import UserService
 
 logger = getLogger(__name__)
 
-WIRE_TO: List[str] = []
+WIRE_TO: list[str] = []
 
 
 class Database:

--- a/src/containers.py
+++ b/src/containers.py
@@ -16,7 +16,7 @@ from sqlalchemy.ext.asyncio import create_async_engine
 from sqlalchemy.orm import sessionmaker
 
 from src.config import config_dict
-from src.helpers.sqlalchemy_helpers import BaseModel
+from src.helpers.sqlalchemy_helpers import mapper_registry
 from src.models import Quest
 from src.models import User
 from src.repositories import BaseRepository
@@ -44,7 +44,7 @@ class Database:
 
     async def create_database(self) -> None:
         current_session = self.get_session()
-        await current_session.run_sync(BaseModel.metadata.create_all)
+        await current_session.run_sync(mapper_registry.metadata.create_all)
 
     def get_session(self) -> AsyncSession:
         return self._session_factory()

--- a/src/helpers/message_helpers.py
+++ b/src/helpers/message_helpers.py
@@ -1,5 +1,3 @@
-from typing import List
-
 from src.helpers.constants import BLOCK_POST_TEXT
 from src.helpers.constants import BLOCK_PRE_TEXT
 from src.helpers.constants import BOX_VERTICAL_CHAR
@@ -17,7 +15,7 @@ def _create_single_quest_line(first_column: str, second_column: str, line_length
     return single_line
 
 
-def format_quest_board(quests: List[Quest]) -> str:
+def format_quest_board(quests: list[Quest]) -> str:
     """
     This function formats a list of quests to look like a quest board
     The formatting is normalized so that all quest names and XP values start at the same char position

--- a/src/helpers/sqlalchemy_helpers.py
+++ b/src/helpers/sqlalchemy_helpers.py
@@ -2,8 +2,6 @@ import re
 from dataclasses import dataclass
 from dataclasses import field
 from typing import Any
-from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -63,20 +61,20 @@ class JoinQueryHandler(QueryHandler):
 
 @dataclass
 class QueryArgs:  # pylint: disable=R0902
-    filter_list: Optional[List[SQLLogicType]] = None
-    filter_dict: Optional[Dict[str, Any]] = None
-    eager_options: Optional[List] = None
-    order_by_list: Optional[List[Union[Column, UnaryExpression]]] = None
+    filter_list: Optional[list[SQLLogicType]] = None
+    filter_dict: Optional[dict[str, Any]] = None
+    eager_options: Optional[list] = None
+    order_by_list: Optional[list[Union[Column, UnaryExpression]]] = None
     join_list: Optional[JoinListType] = None
-    distinct_on_list: Optional[List[Optional[Column]]] = None
-    group_by_list: Optional[List[Column]] = None
-    having_list: Optional[List[SQLLogicType]] = None
+    distinct_on_list: Optional[list[Optional[Column]]] = None
+    group_by_list: Optional[list[Column]] = None
+    having_list: Optional[list[SQLLogicType]] = None
 
     def __post_init__(self) -> None:
         if not self.group_by_list and self.having_list:
             raise Warning("Defining query with having clause but no group by clause")
 
-    def get_query_handlers(self) -> List[QueryHandler]:
+    def get_query_handlers(self) -> list[QueryHandler]:
         query_handlers = [
             DictQueryHandler("filter_by", self.filter_dict),
             JoinQueryHandler("join", self.join_list),

--- a/src/helpers/sqlalchemy_helpers.py
+++ b/src/helpers/sqlalchemy_helpers.py
@@ -115,5 +115,5 @@ class TableMeta(type):
         super().__init__(classname, *args, **kwargs)
 
 
-def case_insensitive_str_compare(column: Column, value: str) -> SQLLogicType:
+def case_insensitive_str_compare(column: str, value: str) -> SQLLogicType:
     return func.lower(column) == value.lower()

--- a/src/repositories.py
+++ b/src/repositories.py
@@ -66,7 +66,7 @@ class BaseRepository(ABC, Generic[BaseModelType]):
 
     async def get_count(self, query_args: Optional[QueryArgs] = None) -> int:
         query = await self.get_query_with_entities(
-            entities_list=[func.count(self.model.id)],  # type: ignore[attr-defined] # issue with TypeVar bound
+            entities_list=[func.count(self.model.id)],
             query_args=query_args,
         )
         count = cast(int, query.scalars().first())

--- a/src/repositories.py
+++ b/src/repositories.py
@@ -4,7 +4,6 @@ from dataclasses import field
 from typing import Any
 from typing import Callable
 from typing import Generic
-from typing import List
 from typing import Optional
 from typing import Type
 from typing import cast
@@ -32,7 +31,7 @@ class BaseRepository(ABC, Generic[BaseModelType]):
             self._session = self.session_factory()
         return self._session
 
-    def _query(self, query_args: Optional[QueryArgs], to_select: List[EntitiesType] = None) -> Executable:
+    def _query(self, query_args: Optional[QueryArgs], to_select: list[EntitiesType] = None) -> Executable:
         query_handlers = query_args.get_query_handlers() if query_args else []
         to_select = to_select or [self.model]
         query: Executable = select(*to_select)
@@ -46,22 +45,22 @@ class BaseRepository(ABC, Generic[BaseModelType]):
         return result
 
     async def get_query_with_entities(
-        self, entities_list: List[EntitiesType], query_args: Optional[QueryArgs] = None
+        self, entities_list: list[EntitiesType], query_args: Optional[QueryArgs] = None
     ) -> Result:
         query = self._query(query_args, to_select=entities_list)
         result: Result = await self.session.execute(query)
         return result
 
-    async def get_all(self, query_args: Optional[QueryArgs] = None) -> List[BaseModelType]:
+    async def get_all(self, query_args: Optional[QueryArgs] = None) -> list[BaseModelType]:
         query = await self.get_query(query_args)
-        res: List[BaseModelType] = query.scalars().all()
+        res: list[BaseModelType] = query.scalars().all()
         return res
 
     async def get_all_with_entities(
-        self, entities_list: List[EntitiesType], query_args: Optional[QueryArgs] = None
-    ) -> List[tuple]:
+        self, entities_list: list[EntitiesType], query_args: Optional[QueryArgs] = None
+    ) -> list[tuple]:
         query = await self.get_query_with_entities(entities_list=entities_list, query_args=query_args)
-        res: List[tuple] = query.scalars().all()
+        res: list[tuple] = query.scalars().all()
         return res
 
     async def get_count(self, query_args: Optional[QueryArgs] = None) -> int:
@@ -83,7 +82,7 @@ class BaseRepository(ABC, Generic[BaseModelType]):
         return result
 
     async def get_first_with_entities(
-        self, entities_list: List[EntitiesType], query_args: Optional[QueryArgs] = None
+        self, entities_list: list[EntitiesType], query_args: Optional[QueryArgs] = None
     ) -> Optional[tuple]:
         query = await self.get_query_with_entities(entities_list=entities_list, query_args=query_args)
         result: Optional[tuple] = query.scalars().first()

--- a/src/services.py
+++ b/src/services.py
@@ -1,6 +1,5 @@
 from logging import Logger
 from logging import getLogger
-from typing import List
 from typing import Optional
 
 from sqlalchemy.orm import selectinload
@@ -56,6 +55,6 @@ class QuestService(BaseService):
         await self._repository.session.commit()
         return GOOD_LUCK_ADVENTURER.format(quest_name)
 
-    async def get_all_quests(self) -> List[Quest]:
+    async def get_all_quests(self) -> list[Quest]:
         quests = await self._repository.get_all()
         return quests

--- a/src/typeshed.py
+++ b/src/typeshed.py
@@ -23,7 +23,7 @@ from sqlalchemy.sql.functions import Function
 from sqlalchemy.sql.selectable import CTE
 
 if TYPE_CHECKING:
-    from src.helpers.sqlalchemy_helpers import BaseModel  # noqa
+    from src.models import CoreModelMixin  # noqa
 
     BooleanColumnElement = ColumnElement[Boolean]
 else:
@@ -63,7 +63,7 @@ class ConfigDict(TypedDict):
 
 
 SQLLogicType = Union[BinaryExpression, BooleanClauseList, bool, BooleanColumnElement]
-JoinOnType = Union[Type["BaseModel"], AliasedClass, RelationshipProperty]
+JoinOnType = Union[Type["CoreModelMixin"], AliasedClass, RelationshipProperty]
 
 
 @dataclass
@@ -92,5 +92,5 @@ JoinListType = Sequence[
     ]
 ]
 
-EntitiesType = Union[Column, Label, Type["BaseModel"], Function]
-BaseModelType = TypeVar("BaseModelType", bound="BaseModel")  # pylint: disable=C0103
+EntitiesType = Union[Column, Label, Type["CoreModelMixin"], Function]
+BaseModelType = TypeVar("BaseModelType", bound="CoreModelMixin")  # pylint: disable=C0103

--- a/src/typeshed.py
+++ b/src/typeshed.py
@@ -4,7 +4,6 @@ from typing import Literal
 from typing import Optional
 from typing import Sequence
 from typing import TYPE_CHECKING
-from typing import Tuple
 from typing import Type
 from typing import TypeVar
 from typing import TypedDict
@@ -72,7 +71,7 @@ class JoinStruct:
     join_on: Union[Optional[SQLLogicType], RelationshipProperty] = field(default=None)
     use_outer_join: bool = field(default=False)
 
-    def get_join_data(self) -> Union[Tuple[JoinOnType], Tuple[JoinOnType, Union[SQLLogicType, RelationshipProperty]]]:
+    def get_join_data(self) -> Union[tuple[JoinOnType], tuple[JoinOnType, Union[SQLLogicType, RelationshipProperty]]]:
         if self.join_on is not None:
             return self.join_model, self.join_on
         return (self.join_model,)
@@ -87,8 +86,8 @@ JoinListType = Sequence[
     Union[
         FromClause,
         JoinStruct,
-        Tuple[JoinOnType, Union[SQLLogicType, RelationshipProperty]],
-        Tuple[CTE, SQLLogicType],
+        tuple[JoinOnType, Union[SQLLogicType, RelationshipProperty]],
+        tuple[CTE, SQLLogicType],
     ]
 ]
 


### PR DESCRIPTION
Converts all implementation of models to use `dataclasses` and revert `__repr__` implementation for what is available in `dataclasses`